### PR TITLE
Publish from release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,22 @@ jobs:
         with:
           name: ${{ matrix.target.artifact-name }}
           path: compiler/target/${{ matrix.target.target }}/release/${{ matrix.target.build-name }}
+  
+  # Artifactory restricts publishing to certain branch , it will not accept publishing from main-atl
+  sync-to-release:
+    name: Sync main-atl to release branch
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.repository == 'atlassian-forks/relay' && github.ref == 'refs/heads/main-atl'
+    needs: [js-tests, js-lint, typecheck, build-tests, build-compiler]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Sync main-atl to release branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push origin main-atl:release --force-with-lease
 
   main-release:
     name: Publish to NPM
@@ -273,7 +289,7 @@ jobs:
           chmod +x macos-arm64/relay
 
       - name: Build latest (main) version
-        if: github.ref == 'refs/heads/main-atl'
+        if: github.ref == 'refs/heads/release'
         run: yarn gulp mainrelease
         env:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
@@ -283,18 +299,18 @@ jobs:
         run: yarn gulp release
 
       - name: Get Artifact Publish Token
-        if: github.ref == 'refs/heads/main-atl' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: github.ref == 'refs/heads/release' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         id: publish-token
         uses: atlassian-labs/artifact-publish-token@v1.0.1
         with:
           output-modes: npm
 
       - name: Publish to npm
-        if: github.ref == 'refs/heads/main-atl' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        if: github.ref == 'refs/heads/release' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         run: |
           for pkg in dist/*; do
             npm publish "./$pkg" ${TAG} --userconfig=./.npmrc-public --@atlassian:registry="https://packages.atlassian.com/api/npm/npm-public/"
           done
         env:
-          TAG: ${{ github.ref == 'refs/heads/main-atl' && '--tag=main-atl' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
+          TAG: ${{ github.ref == 'refs/heads/release' && '--tag=release' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
           NPM_REGISTRY: ${{ secrets.REGISTRY }}


### PR DESCRIPTION
Artifactory accepts publishing from branches named: "master", "main" or "release". Modified CI to sync main-atl to release branch and publishing from release branch.