### PR TITLE
- Implement version packages release flow

### DIFF
--- a/.github/actions/setup-publishing-environment/action.yml
+++ b/.github/actions/setup-publishing-environment/action.yml
@@ -1,0 +1,48 @@
+name: Setup publishing environment
+description: Installs JS dependencies, downloads all Relay compiler binary artifacts, and marks them as executable
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 20.x
+        registry-url: https://registry.npmjs.org/
+        cache: 'yarn'
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile --ignore-scripts
+    - name: Download artifact relay-bin-linux-x64
+      uses: actions/download-artifact@v7
+      with:
+        name: relay-bin-linux-x64
+        path: artifacts/linux-x64
+    - name: Download artifact relay-bin-linux-arm64
+      uses: actions/download-artifact@v7
+      with:
+        name: relay-bin-linux-arm64
+        path: artifacts/linux-arm64
+    - name: Download artifact relay-bin-macos-x64
+      uses: actions/download-artifact@v7
+      with:
+        name: relay-bin-macos-x64
+        path: artifacts/macos-x64
+    - name: Download artifact relay-bin-macos-arm64
+      uses: actions/download-artifact@v7
+      with:
+        name: relay-bin-macos-arm64
+        path: artifacts/macos-arm64
+    - name: Download artifact relay-bin-win-x64
+      uses: actions/download-artifact@v7
+      with:
+        name: relay-bin-win-x64
+        path: artifacts/win-x64
+    - name: Mark binaries as executable
+      shell: bash
+      working-directory: artifacts
+      run: |
+        chmod +x linux-x64/relay
+        chmod +x linux-arm64/relay
+        chmod +x macos-x64/relay
+        chmod +x macos-arm64/relay

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on: [push, pull_request]
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   vscode-extension-lint:
@@ -225,85 +226,69 @@ jobs:
           name: ${{ matrix.target.artifact-name }}
           path: compiler/target/${{ matrix.target.target }}/release/${{ matrix.target.build-name }}
 
-  main-release:
-    name: Publish to NPM
+  create-release-pr:
+    name: Create PR to release branch for Artifactory publish
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'atlassian-forks/relay'
-    needs: [js-tests, js-lint, typecheck, build-tests, build-compiler]
+    if: github.ref == 'refs/heads/main-atl' && github.event_name == 'push' && github.repository == 'atlassian-forks/relay'
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-          registry-url: https://registry.npmjs.org/
-          cache: 'yarn'
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts
-      - name: Download artifact relay-bin-linux-x64
-        uses: actions/download-artifact@v7
+          fetch-depth: 0
+      - name: Create or update pull request to release branch
+        uses: peter-evans/create-pull-request@v7
         with:
-          name: relay-bin-linux-x64
-          path: artifacts/linux-x64
-      - name: Download artifact relay-bin-linux-arm64
-        uses: actions/download-artifact@v7
-        with:
-          name: relay-bin-linux-arm64
-          path: artifacts/linux-arm64
-      - name: Download artifact relay-bin-macos-x64
-        uses: actions/download-artifact@v7
-        with:
-          name: relay-bin-macos-x64
-          path: artifacts/macos-x64
-      - name: Download artifact relay-bin-macos-arm64
-        uses: actions/download-artifact@v7
-        with:
-          name: relay-bin-macos-arm64
-          path: artifacts/macos-arm64
-      - name: Download artifact relay-bin-win-x64
-        uses: actions/download-artifact@v7
-        with:
-          name: relay-bin-win-x64
-          path: artifacts/win-x64
-      - name: Mark binaries as executable
-        working-directory: artifacts
-        run: |
-          chmod +x linux-x64/relay
-          chmod +x linux-arm64/relay
-          chmod +x macos-x64/relay
-          chmod +x macos-arm64/relay
+          base: release
+          branch: main-atl
+          title: "[Main release] Merge to trigger Artifactory publish to NPM (main-atl → release)"
+          body: |
+            This PR was automatically created by CI when a push was made to `main-atl`.
+            Merging this PR will trigger the `main-release` job and publish to Artifactory.
+          labels: release
 
-      # Artifactory restricts publishing to certain branch names, it will not accept publishing from main-atl
-      - name: Sync main-atl to release branch
-        if: github.ref == 'refs/heads/main-atl'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main-atl release --depth=1
-          git push origin main-atl:release --force-with-lease
+  main-release:
+    name: Publish release branch to Artifactory
+    runs-on: ubuntu-latest
+    if:  github.ref == 'refs/heads/release' && github.event_name == 'push' && github.repository == 'atlassian-forks/relay'
+    needs: [js-tests, js-lint, typecheck, build-tests, build-compiler]
+    steps:
+      - name: Prepare dependencies
+        uses: ./.github/actions/setup-publishing-environment
 
-      - name: Build latest (main) version
-        if: github.ref == 'refs/heads/release'
+      - name: Build latest release version
         run: yarn gulp mainrelease
         env:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
 
-      - name: Build release version
-        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-        run: yarn gulp release
-
       - name: Get Artifact publish token
-        if: github.ref == 'refs/heads/release'
         id: publish-token
         uses: atlassian-labs/artifact-publish-token@v1.0.1
         with:
           output-modes: npm
 
-      - name: Publish to npm
-        if: github.ref == 'refs/heads/release' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+      - name: Publish to Artifactory
         run: |
           for pkg in dist/*; do
-            npm publish "./$pkg" ${TAG} --userconfig=./.npmrc-public --@atlassian:registry="https://packages.atlassian.com/api/npm/npm-public/"
+            npm publish "./$pkg" --tag=main-atl --userconfig=./.npmrc-public --@atlassian:registry="https://packages.atlassian.com/api/npm/npm-public/"
+          done
+
+  version-release:
+    name: Publish version release to NPM
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && github.event_name == 'push' && github.repository == 'atlassian-forks/relay'
+    needs: [js-tests, js-lint, typecheck, build-tests, build-compiler]
+    steps:
+      - name: Prepare dependencies
+        uses: ./.github/actions/setup-publishing-environment
+
+      - name: Build release version
+        run: yarn gulp release
+
+      - name: Publish to npm
+        run: |
+          for pkg in dist/*; do
+            npm publish "./$pkg" ${TAG}
           done
         env:
-          TAG: ${{ github.ref == 'refs/heads/release' && '--tag=main-atl' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
+          TAG: ${{ (contains(github.ref_name, '-rc.') && '--tag=dev') || '' }}
           NPM_REGISTRY: ${{ secrets.REGISTRY }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -242,7 +242,7 @@ const relayCompiler = gulp.parallel(
           .readFileSync(path.join(DIST, 'relay-compiler', 'package.json'))
           .toString(),
       );
-      pkg.name = 'atl-' + pkg.name;
+      pkg.name = '@atlassian/' + pkg.name;
       fs.writeFileSync(
         path.join(DIST, 'relay-compiler', 'package.json'),
         JSON.stringify(pkg, null, 2),


### PR DESCRIPTION
Due to Artifactory publishing restrictions we can only publish from certain branches. This PR introduces a version packages style pattern, where when changes are merged into `main-atl` a release PR will be created. When merged, this will trigger a publish to Artifactory and NPM.